### PR TITLE
fix: mock state properties to pass the test

### DIFF
--- a/trivia/tests/unit/Question.spec.js
+++ b/trivia/tests/unit/Question.spec.js
@@ -9,6 +9,10 @@ localVue.use(Vuex)
 const store = new Vuex.Store({
   state: {
     isAnswered: true,
+    round: 0,
+    questions: [{
+      options: null
+    }]
   },
 })
 
@@ -18,6 +22,6 @@ describe('Question.vue', () => {
       store,
       localVue,
     })
-    expect(wrapper.find('button').isVisible()).toBe('true')
+    expect(wrapper.find('button').isVisible()).toBe(true)
   })
 })


### PR DESCRIPTION
Unfortunately, Jest was pointing to the wrong line when the test was failing, complaining about the CSS color definition, when in reality, the problem was completely different...

The computed properties were depending on data be present in the Vuex store, but those were missing and it couldn't render the component. I added the minimum values for the test to pass 🎉